### PR TITLE
Add the token snapshot function

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library( eosio_chain
               abi_serializer.cpp
               asset.cpp
               snapshot.cpp
+              token_snapshot.cpp
 
              webassembly/wavm.cpp
              webassembly/wabt.cpp

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -8,6 +8,8 @@
 #include <eosio/chain/account_object.hpp>
 #include <eosio/chain/snapshot.hpp>
 
+#include <eosio/chain/asset.hpp>
+
 namespace chainbase {
    class database;
 }
@@ -16,6 +18,7 @@ namespace chainbase {
 namespace eosio { namespace chain {
 
    class authorization_manager;
+   class token_snapshot_writer;
 
    namespace resource_limits {
       class resource_limits_manager;
@@ -206,6 +209,8 @@ namespace eosio { namespace chain {
 
          sha256 calculate_integrity_hash()const;
          void write_snapshot( const snapshot_writer_ptr& snapshot )const;
+
+         bool write_token_snapshot( const std::shared_ptr<token_snapshot_writer>& snapshot, name code, std::string symbol )const;
 
          void check_contract_list( account_name code )const;
          void check_action_list( account_name code, action_name action )const;

--- a/libraries/chain/include/eosio/chain/exceptions.hpp
+++ b/libraries/chain/include/eosio/chain/exceptions.hpp
@@ -460,6 +460,14 @@ namespace eosio { namespace chain {
                                     3170007, "The configured snapshot directory does not exist" )
       FC_DECLARE_DERIVED_EXCEPTION( snapshot_exists_exception,  producer_exception,
                                     3170008, "The requested snapshot already exists" )
+      FC_DECLARE_DERIVED_EXCEPTION( token_snapshot_create_exception,  producer_exception,
+                                    3170009, "Create token snapshot failed" )
+      FC_DECLARE_DERIVED_EXCEPTION( token_snapshot_validate_exception,  producer_exception,
+                                    3170010, "Validate token snapshot exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( token_snapshot_IO_exception,  producer_exception,
+                                    3170011, "Binary snapshot throw IO exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( token_snapshot_function_disabled,  producer_exception,
+                                    3170012, "Token snapshot function is disabled" )
 
    FC_DECLARE_DERIVED_EXCEPTION( reversible_blocks_exception,           chain_exception,
                                  3180000, "Reversible Blocks exception" )
@@ -519,4 +527,6 @@ namespace eosio { namespace chain {
                                  3240000, "Snapshot exception" )
       FC_DECLARE_DERIVED_EXCEPTION( snapshot_validation_exception,   snapshot_exception,
                                     3240001, "Snapshot Validation Exception" )
+      FC_DECLARE_DERIVED_EXCEPTION( snapshot_read_exception,   snapshot_exception,
+                                    3240002, "Snapshot read Exception" )
 } } // eosio::chain

--- a/libraries/chain/include/eosio/chain/token_snapshot.hpp
+++ b/libraries/chain/include/eosio/chain/token_snapshot.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <eosio/chain/exceptions.hpp>
+#include <iostream>
+
+namespace eosio { namespace chain {
+
+class iostream_token_snapshot
+{
+    protected:
+    struct token_snapshot_head{
+        static const uint32_t magic_number = 0x30510550;
+        static const uint32_t current_snapshot_version = 1;
+    };
+    static uint64_t end_marker;
+};
+
+class token_snapshot_writer:public iostream_token_snapshot
+{
+    public:
+    explicit token_snapshot_writer(std::ostream& snapshot);
+    void finalize();
+    void write_file_head();
+    auto& write(const char* d, size_t s)
+    {
+        return snapshot.write(d,s);
+    }
+    private:
+    std::ostream&  snapshot;
+    std::streampos pos;
+};
+
+class token_snapshot_reader:public iostream_token_snapshot
+{
+    public:
+    explicit token_snapshot_reader(std::istream& snapshot);
+    void validate();
+    void exceptions();
+    void seekg_valid_pos();
+    std::streampos get_file_size();
+    std::streampos get_valid_file_size();
+    std::streampos get_end_pos();
+    auto& read(char* d, size_t s)
+    {
+        return snapshot.read(d,s);
+    }
+    std::streampos get_pos()
+    {
+        return snapshot.tellg();
+    }
+   
+    private:
+    std::istream&  snapshot;
+    std::streampos pos;
+};
+
+}}

--- a/libraries/chain/token_snapshot.cpp
+++ b/libraries/chain/token_snapshot.cpp
@@ -1,0 +1,115 @@
+#include <eosio/chain/token_snapshot.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <fc/scoped_exit.hpp>
+
+namespace eosio { namespace chain {
+
+uint64_t iostream_token_snapshot::end_marker = std::numeric_limits<uint64_t>::max();
+
+token_snapshot_writer::token_snapshot_writer(std::ostream& snapshot)
+:snapshot(snapshot)
+,pos(snapshot.tellp())
+{
+}
+
+void token_snapshot_writer::write_file_head()
+{
+   // write magic number
+   auto totem = token_snapshot_head::magic_number;
+   snapshot.write((char*)&totem, sizeof(totem));
+
+   // write version
+   auto version = token_snapshot_head::current_snapshot_version;
+   snapshot.write((char*)&version, sizeof(version));
+}
+
+void token_snapshot_writer::finalize()
+{
+   // write a placeholder for the section size
+   snapshot.write((char*)&end_marker, sizeof(end_marker));
+}
+
+token_snapshot_reader::token_snapshot_reader(std::istream& snapshot)
+:snapshot(snapshot)
+,pos(snapshot.tellg())
+{
+}
+
+void token_snapshot_reader::exceptions()
+{
+    snapshot.exceptions(std::istream::failbit|std::istream::eofbit);
+}
+
+void token_snapshot_reader::seekg_valid_pos()
+{
+    std::streampos file_head_size = std::streamoff(sizeof(token_snapshot_head::magic_number)+sizeof(token_snapshot_head::current_snapshot_version));
+    snapshot.seekg(file_head_size,std::ios::beg);
+}
+
+std::streampos token_snapshot_reader::get_file_size()
+{
+    snapshot.seekg(0,std::ios::end);
+    std::streampos file_size = snapshot.tellg();
+    snapshot.seekg(0,std::ios::beg);
+    return file_size;
+}
+
+std::streampos token_snapshot_reader::get_valid_file_size()
+{
+    std::streampos file_size = get_file_size();
+
+    std::streampos file_head_size = std::streamoff(sizeof(token_snapshot_head::magic_number)+sizeof(token_snapshot_head::current_snapshot_version));
+    std::streampos end_maker_size = std::streamoff(sizeof(end_marker));
+    snapshot.seekg(file_head_size,std::ios::beg);
+
+    std::streampos valid_file_size = file_size - file_head_size - end_maker_size;
+    snapshot.seekg(0,std::ios::beg);
+    return valid_file_size;
+}
+
+std::streampos token_snapshot_reader::get_end_pos()
+{
+    std::streampos end_marker_size = std::streamoff(sizeof(end_marker));
+    snapshot.seekg(-end_marker_size,std::ios::end);
+    std::streampos pos = snapshot.tellg();
+    snapshot.seekg(0,std::ios::beg);
+    return pos;
+}
+
+void token_snapshot_reader::validate()
+{
+  snapshot.exceptions(std::istream::failbit|std::istream::eofbit);
+
+  try {
+    // validate totem
+    auto expected_totem = token_snapshot_head::magic_number;
+    decltype(expected_totem) actual_totem;
+    snapshot.read((char*)&actual_totem, sizeof(actual_totem));
+    EOS_ASSERT(actual_totem == expected_totem, token_snapshot_validate_exception,
+             "Validate token snapshot exception");
+
+    // validate version
+    auto expected_version = token_snapshot_head::current_snapshot_version;
+    decltype(expected_version) actual_version;
+    snapshot.read((char*)&actual_version, sizeof(actual_version));
+    EOS_ASSERT(actual_version == expected_version, token_snapshot_validate_exception,
+                "Validate token snapshot exception");
+    // validate end_marker
+    std::streampos end_maker_size = std::streamoff(sizeof(iostream_token_snapshot::end_marker));
+    std::streampos file_size = get_file_size();
+    snapshot.seekg((file_size-end_maker_size),std::ios::beg);
+
+    uint64_t end_marker = 0;
+    snapshot.read((char*)&end_marker,sizeof(end_marker));
+    if(end_marker != iostream_token_snapshot::end_marker){
+      EOS_ASSERT(false, token_snapshot_validate_exception,
+                "Validate token snapshot exception");
+    }
+
+  } catch( const std::exception& e ) {  
+    EOS_ASSERT(false, token_snapshot_IO_exception,
+                "Binary snapshot throw IO exception (${what})",("what",e.what()));
+  }
+}
+
+}}

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -59,6 +59,9 @@ using namespace eosio;
      api_handle.call_name(); \
      eosio::detail::producer_api_plugin_response result{"ok"};
 
+#define INVOKE_V_R_T(api_handle, call_name, in_param) \
+     auto result = api_handle.call_name(fc::json::from_string(body).as<in_param>()); \
+
 
 void producer_api_plugin::plugin_startup() {
    ilog("starting producer_api_plugin");
@@ -90,6 +93,10 @@ void producer_api_plugin::plugin_startup() {
             INVOKE_R_V(producer, get_integrity_hash), 201),
        CALL(producer, producer, create_snapshot,
             INVOKE_R_V(producer, create_snapshot), 201),
+       CALL(producer, producer, create_token_snapshot,
+            INVOKE_V_R_T(producer, create_token_snapshot, producer_plugin::token_snapshot_params), 201),
+       CALL(producer, producer, get_token_snapshot_info,
+            INVOKE_V_R_T(producer, get_token_snapshot_info, producer_plugin::get_token_snapshot_params), 201),
    });
 }
 

--- a/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/producer_plugin.hpp
@@ -50,6 +50,28 @@ public:
       std::string          snapshot_name;
    };
 
+   struct token_snapshot_params {
+      account_name code; //contranct account
+      fc::optional<string> symbol;
+   };
+
+   struct token_snapshot_results{
+       uint32_t head_block_num;
+       std::string snapshot_path;
+   };
+
+   struct get_token_snapshot_params{
+       account_name code;
+       fc::optional<string> symbol;
+       fc::optional<uint32_t> block_num;
+   };
+
+   struct get_token_snapshot_results{
+       std::string account;
+       std::string amount;
+       std::string symbol;
+   };
+
    producer_plugin();
    virtual ~producer_plugin();
 
@@ -81,6 +103,12 @@ public:
    integrity_hash_information get_integrity_hash() const;
    snapshot_information create_snapshot() const;
 
+   token_snapshot_results create_token_snapshot(const token_snapshot_params& params) const;
+   vector<get_token_snapshot_results> get_token_snapshot_info(const get_token_snapshot_params& params) const;
+
+   template< typename T>
+   void get_token_snapshot(std::shared_ptr<T>& reader ,vector<get_token_snapshot_results>& results) const;
+
    signal<void(const chain::producer_confirmation&)> confirmed_block;
 private:
    std::shared_ptr<class producer_plugin_impl> my;
@@ -93,4 +121,7 @@ FC_REFLECT(eosio::producer_plugin::greylist_params, (accounts));
 FC_REFLECT(eosio::producer_plugin::whitelist_blacklist, (actor_whitelist)(actor_blacklist)(contract_whitelist)(contract_blacklist)(action_blacklist)(key_blacklist) )
 FC_REFLECT(eosio::producer_plugin::integrity_hash_information, (head_block_id)(integrity_hash))
 FC_REFLECT(eosio::producer_plugin::snapshot_information, (head_block_id)(snapshot_name))
-
+FC_REFLECT(eosio::producer_plugin::token_snapshot_params, (code)(symbol))
+FC_REFLECT(eosio::producer_plugin::token_snapshot_results, (head_block_num)(snapshot_path))
+FC_REFLECT(eosio::producer_plugin::get_token_snapshot_params, (code)(symbol)(block_num))
+FC_REFLECT(eosio::producer_plugin::get_token_snapshot_results, (account)(amount)(symbol))

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -101,6 +101,9 @@ namespace eosio { namespace client { namespace http {
    const string get_schedule_func = chain_func_base + "/get_producer_schedule";
    const string get_required_keys = chain_func_base + "/get_required_keys";
 
+   const string producer_func_base = "/v1/producer";
+   const string create_token_snapshot_func = producer_func_base + "/create_token_snapshot";
+   const string get_token_snapshot_info_func = producer_func_base + "/get_token_snapshot_info";
 
    const string history_func_base = "/v1/history";
    const string get_actions_func = history_func_base + "/get_actions";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -1811,6 +1811,20 @@ int main( int argc, char** argv ) {
    // create account
    auto createAccount = create_account_subcommand( create, true /*simple*/ );
 
+   // create token_snapshot
+   string code;
+   string symbol;
+   auto create_token_snapshot = create->add_subcommand( "token_snapshot", localized("Undetermined"), true);
+   create_token_snapshot->add_option( "contract", code, localized("The contract that operates the currency") )->required();
+   create_token_snapshot->add_option( "symbol", symbol, localized("The symbol for the currency if the contract operates multiple currencies") );
+   create_token_snapshot->set_callback([&] {
+      auto result = call(create_token_snapshot_func, fc::mutable_variant_object
+         ("code", code)
+         ("symbol", symbol.empty() ? fc::variant() : symbol)
+      );
+      std::cout << fc::json::to_pretty_string(result) << std::endl;
+   });
+
    // convert subcommand
    auto convert = app.add_subcommand("convert", localized("Pack and unpack transactions"), false); // TODO also add converting action args based on abi from here ?
    convert->require_subcommand();
@@ -1902,6 +1916,22 @@ int main( int argc, char** argv ) {
    get->add_subcommand("info", localized("Get current blockchain information"))->set_callback([] {
       std::cout << fc::json::to_pretty_string(get_info()) << std::endl;
    });
+
+   //get token_snapshot_info
+   auto get_token_snapshot_info = get->add_subcommand( "token_snapshot_info", localized("Get token snapshot file information"), true);
+   string block_num;
+   get_token_snapshot_info->add_option( "contract", code, localized("The contract that operates the currency") )->required();
+   get_token_snapshot_info->add_option( "symbol", symbol, localized("The symbol for the currency if the contract operates multiple currencies") )->required();
+   get_token_snapshot_info->add_option( "block_num", block_num, localized("Snapshot block number") )->required();
+
+   get_token_snapshot_info->set_callback([&] {
+      auto result = call(get_token_snapshot_info_func, fc::mutable_variant_object
+         ("code", code)
+         ("symbol", symbol)
+         ("block_num", block_num)
+      );
+      std::cout << fc::json::to_pretty_string(result) << std::endl;
+   });  
 
    // get block
    string blockArg;
@@ -2008,7 +2038,6 @@ int main( int argc, char** argv ) {
 
    // get table
    string scope;
-   string code;
    string table;
    string lower;
    string upper;
@@ -2075,7 +2104,6 @@ int main( int argc, char** argv ) {
 
    // currency accessors
    // get currency balance
-   string symbol;
    auto get_currency = get->add_subcommand( "currency", localized("Retrieve information related to standard currencies"), true);
    get_currency->require_subcommand();
    auto get_balance = get_currency->add_subcommand( "balance", localized("Retrieve the balance of an account for a given currency"), false);


### PR DESCRIPTION
Add the token snapshot function
Note: the token snapshot function can be started or disabled at node startup through the config.ini file. You need to add the configuration in the startup file.

allow-use-token-snapshot = true